### PR TITLE
added docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.5
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT [ "python", "magictune.py" ]
+
+CMD [ "--help" ]

--- a/Dockerfile.cron
+++ b/Dockerfile.cron
@@ -1,0 +1,15 @@
+FROM python:3.5
+
+WORKDIR /app
+
+ENV CRON_INTERVAL="0 0 * * *"
+ENV DRY_RUN=true
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		cron
+
+COPY . /app
+
+RUN pip install -r requirements.txt
+
+CMD ./cmd.sh

--- a/cmd.sh
+++ b/cmd.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+cd /app
+
+cat >> /etc/cron.d/magic-cron <<EOL
+SHELL=/bin/bash
+BASH_ENV=/app/cron.env
+$CRON_INTERVAL /app/cron.sh
+EOL
+chmod 0644 /etc/cron.d/magic-cron
+crontab /etc/cron.d/magic-cron
+
+printenv > cron.env
+
+echo "Starting cron in foreground"
+cron -f

--- a/cron.sh
+++ b/cron.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /app
+python magictune.py --dry-run=$DRY_RUN run > /proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
`Dockerfile` just wraps the command, use as you would use `python magictune.py` directly
`Dockerfile.cron` runs the `run` job in a cron. You have CRON_INTERVAL and DRY_RUN you can set as env vars to modify behaviour. Defaults are to run daily and with dry run activated.